### PR TITLE
run nullsafety migration for dart 2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0]
+- Nullsafety migration
+
 ## [1.1.1] - 2019-08-12
 ### Changed
 - Used cookie parsing function from dart:io

--- a/example/example.dart
+++ b/example/example.dart
@@ -8,7 +8,7 @@ void main() {
   var handler = const shelf.Pipeline()
       .addMiddleware(cookieParser())
       .addHandler((req) async {
-    CookieParser cookies = req.context['cookies'];
+    CookieParser cookies = req.context['cookies'] as CookieParser;
     if (cookies.get('ping') != null) {
       // Clear cookies because Shelf currently only supports
       // a single `Set-Cookie` header in response.

--- a/lib/src/cookie_parser.dart
+++ b/lib/src/cookie_parser.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:collection/collection.dart' show IterableExtension;
 import 'package:shelf/shelf.dart';
 
 /// Parses cookies from the `Cookie` header of a [Request].
@@ -14,7 +15,7 @@ class CookieParser {
   final List<Cookie> cookies = [];
 
   /// Creates a new [CookieParser] by parsing the `Cookie` header [value].
-  CookieParser.fromCookieValue(String value) {
+  CookieParser.fromCookieValue(String? value) {
     if (value != null) {
       cookies.addAll(_parseCookieString(value));
     }
@@ -29,19 +30,19 @@ class CookieParser {
   bool get isEmpty => cookies.isEmpty;
 
   /// Retrieves a cookie by [name].
-  Cookie get(String name) => cookies
-      .firstWhere((Cookie cookie) => cookie.name == name, orElse: () => null);
+  Cookie? get(String name) => cookies
+      .firstWhereOrNull((Cookie cookie) => cookie.name == name);
 
   /// Adds a new cookie to [cookies] list.
   Cookie set(
     String name,
     String value, {
-    String domain,
-    String path,
-    DateTime expires,
-    bool httpOnly,
-    bool secure,
-    int maxAge,
+    String? domain,
+    String? path,
+    DateTime? expires,
+    bool? httpOnly,
+    bool? secure,
+    int? maxAge,
   }) {
     var cookie = Cookie(name, value);
     if (domain != null) cookie.domain = domain;
@@ -95,7 +96,7 @@ class CookieParser {
 /// Parse a Cookie header value according to the rules in RFC 6265.
 /// This function was adapted from `dart:io`.
 List<Cookie> _parseCookieString(String s) {
-  var cookies = List<Cookie>();
+  var cookies = <Cookie>[];
 
   int index = 0;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_cookie
-version: 1.1.1
+version: 2.0.0
 description: >-
   Cookie parser middleware for the Shelf ecosystem.
   Reads cookies in request, sets cookies in response.
@@ -8,10 +8,11 @@ homepage: https://github.com/izolate/shelf-cookie
 documentation: https://github.com/izolate/shelf-cookie/blob/master/README.md
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  shelf: ^0.7.5
+  shelf: ^1.0.0
+  collection: ^1.15.0
 
 dev_dependencies:
-  test: ^1.6.2
+  test: ^1.16.6

--- a/test/cookie_parser_test.dart
+++ b/test/cookie_parser_test.dart
@@ -12,16 +12,16 @@ void main() {
   test('parses cookies from `cookie` header value', () {
     var cookies = CookieParser.fromCookieValue('foo=bar; baz=qux');
     expect(cookies.isEmpty, isFalse);
-    expect(cookies.get('foo').value, equals('bar'));
-    expect(cookies.get('baz').value, equals('qux'));
+    expect(cookies.get('foo')!.value, equals('bar'));
+    expect(cookies.get('baz')!.value, equals('qux'));
   });
 
   test('parses cookies from raw headers map', () {
     var cookies =
         CookieParser.fromHeader({HttpHeaders.cookieHeader: 'foo=bar; baz=qux'});
     expect(cookies.isEmpty, isFalse);
-    expect(cookies.get('foo').value, equals('bar'));
-    expect(cookies.get('baz').value, equals('qux'));
+    expect(cookies.get('foo')!.value, equals('bar'));
+    expect(cookies.get('baz')!.value, equals('qux'));
   });
 
   test('adds new cookie to cookies list', () {
@@ -29,19 +29,19 @@ void main() {
     expect(cookies.isEmpty, isFalse);
     expect(cookies.get('baz'), isNull);
     cookies.set('baz', 'qux');
-    expect(cookies.get('baz').value, 'qux');
+    expect(cookies.get('baz')!.value, 'qux');
   });
 
   test('removes cookie from cookies list by name', () {
     var cookies = CookieParser.fromCookieValue('foo=bar; baz=qux');
-    expect(cookies.get('baz').value, equals('qux'));
+    expect(cookies.get('baz')!.value, equals('qux'));
     cookies.remove('baz');
     expect(cookies.get('baz'), isNull);
   });
 
   test('clears all cookies in list', () {
     var cookies = CookieParser.fromCookieValue('foo=bar; baz=qux');
-    expect(cookies.get('baz').value, equals('qux'));
+    expect(cookies.get('baz')!.value, equals('qux'));
     cookies.clear();
     expect(cookies.isEmpty, isTrue);
   });


### PR DESCRIPTION
Basically just upgraded dependencies and ran `dart migrate` all tests still pass and it looks reasonable.